### PR TITLE
Fix memory leak issue due to `time.After`

### DIFF
--- a/server.go
+++ b/server.go
@@ -455,8 +455,12 @@ func (svr *Server) Serve() error {
 
 L:
 	for {
+		// Start timer
+		timer := time.NewTimer(svr.timeout)
 		select {
 		case data := <-pktDataChan:
+			// Stop timer in case a packet was received.
+			timer.Stop()
 			if data.err != nil {
 				break L
 			}
@@ -479,7 +483,7 @@ L:
 
 			pktChan <- pkt
 
-		case <-time.After(svr.timeout):
+		case <-timer.C:
 			err = fmt.Errorf("client timed out")
 			close(quit)
 			svr.conn.Close() // shuts down recvPacket


### PR DESCRIPTION
This PR fixes a memory leak issue caused by `time.After` in an infinite loop.

According to the documentation of `time.After`, the GC will not clear the allocated memory until the timer is triggered. Unfortunately, in this case the timer could not be triggered if the server receives a packet from the client and many more. The underlying pointer to `time.Time` is left on the heap increasing the size of the heap over time.

------

The following profiles were obtained after uploading files of size **1 MB, 10 MB, 100 MB and 1 GB** sequentially from the same client.


**Memory Profile archives:** [mem_profiles.zip](https://github.com/OTA-Insight/sftp/files/4140127/mem_profiles.zip)
`mem_after.pprof`: Profile on `master`
`mem_timer.pprof`: Profile with the fix

------
**mem_after.pprof**
<img width="1327" alt="Screenshot 2020-01-31 16 22 24" src="https://user-images.githubusercontent.com/12427142/73551041-f7db5480-4445-11ea-9f8c-b37b2642e7a6.png">

**mem_timer.pprof**
<img width="1425" alt="Screenshot 2020-01-31 16 23 53" src="https://user-images.githubusercontent.com/12427142/73551091-15102300-4446-11ea-95f1-eddeb4466bf8.png">

Note: In the "After" shot, there is no heap allocated for `time.NewTimer`.
